### PR TITLE
Che build update to be able run it as root

### DIFF
--- a/cico_build.sh
+++ b/cico_build.sh
@@ -10,9 +10,11 @@ yum -y install centos-release-scl java-1.8.0-openjdk-devel git patch bzip2 golan
 yum -y install rh-maven33 rh-nodejs4
 git clone https://github.com/eclipse/che
 cd che 
-export NPM_CONFIG_PREFIX=~/.che_node_modules 
+export NPM_CONFIG_PREFIX=~/.che_node_modules
 export PATH=$NPM_CONFIG_PREFIX/bin:$PATH
-scl enable rh-nodejs4 'npm install --unsafe-perm -g bower gulp typings'
+mkdir $NPM_CONFIG_PREFIX
+echo "{ \"allow_root\": true }" > ~/.bowerrc
+scl enable rh-nodejs4 'npm install -g bower gulp typings'
 scl enable rh-maven33 rh-nodejs4 'mvn clean install -Pfast'
 if [ $? -eq 0 ]; then
   # Now lets build the local docker image


### PR DESCRIPTION
Fixed a couple of things:
- Folder $NPM_CONFIG_PREFIX must exist and should be created before running npm install
- To be able to run bower as root `{ "allow_root": true}` must be added to `~/.bowerrc`

By the way if possible it would be preferable to run the build as non root user (but belonging to sudoers group to be able to `yum install`).