### PR TITLE
cico_build.sh syntax error

### DIFF
--- a/cico_build.sh
+++ b/cico_build.sh
@@ -28,6 +28,7 @@ if [ $? -eq 0 ]; then
   if [ $? -ne 0 ]; then
     echo 'Docker Build Failed'
     exit 2
+  fi
 else
   echo 'Build Failed!'
   exit 1


### PR DESCRIPTION
Running the build produced the following error:
> cico_build.sh: line 35: syntax error: unexpected end of file