### PR TITLE
Run the build as a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ CI Runs
 =======
 
 There is a CI job at : https://ci.centos.org/view/Devtools/job/devtools-build-run-che-build-master/ that runs on each merge to master in this repo.
+
+On success, it will push the che container to dockerhub at rhche/che, and another copy is pushed to the local CentOS CI regestry. The CentOS CI Registry hosted image can then be used by other components in the CentOS CI services, either as triggers or as a point of integration.

--- a/build_che.sh
+++ b/build_che.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# this script downloads the src and runs the build
+# to create the che binaries
+
+
+git clone -b ${GIT_BRANCH} ${GIT_REPO}
+cd che 
+mkdir $NPM_CONFIG_PREFIX
+scl enable rh-nodejs4 'npm install -g bower gulp typings'
+scl enable rh-maven33 rh-nodejs4 'mvn clean install -Pfast'

--- a/build_che.sh
+++ b/build_che.sh
@@ -3,6 +3,7 @@
 # this script downloads the src and runs the build
 # to create the che binaries
 
+. config 
 
 git clone -b ${GIT_BRANCH} ${GIT_REPO}
 cd che 

--- a/build_che.sh
+++ b/build_che.sh
@@ -8,5 +8,5 @@
 git clone -b ${GIT_BRANCH} ${GIT_REPO}
 cd che 
 mkdir $NPM_CONFIG_PREFIX
-scl enable rh-nodejs4 'npm install -g bower gulp typings'
+#scl enable rh-nodejs4 'npm install -g bower gulp typings'
 scl enable rh-maven33 rh-nodejs4 'mvn clean install -Pfast'

--- a/cico_build.sh
+++ b/cico_build.sh
@@ -20,6 +20,7 @@ useradd ${BuildUser}
 mkdir -p ${HomeDir}
 chown ${BuildUser}:${BuildUser} ${HomeDir}
 
+cp config ${HomeDir}/
 cd ${HomeDir}
 runuser -u ${BuildUser} ./build_che.sh
 if [ $? -eq 0 ]; then

--- a/config
+++ b/config
@@ -1,0 +1,14 @@
+# Config used by the different scripts
+
+HomeDir=/srv/che-build
+BuildUser=chebuilder
+
+# Until PR https://github.com/eclipse/che/pull/3798 is not 
+# merged we need to build from ibuziuk branch
+# export GIT_REPO=https://github.com/eclipse/che
+# export GIT_BRANCH=master
+export GIT_REPO=https://github.com/ibuziuk/che
+export GIT_BRANCH=CHE-26
+
+export NPM_CONFIG_PREFIX=~/.che_node_modules
+export PATH=$NPM_CONFIG_PREFIX/bin:$PATH


### PR DESCRIPTION
This splits out the run job and should execute the build as user, but retain the docker build as root.