### PR TITLE
Added component analysis lsp plugin to Che build

### DIFF
--- a/build_che.sh
+++ b/build_che.sh
@@ -6,7 +6,15 @@
 . config 
 
 git clone -b ${GIT_BRANCH} ${GIT_REPO}
-cd che 
+export CHE_LOCAL_GIT_REPO=$(pwd)/che
+
+# Inject bayesian files in Che source tree
+git clone https://github.com/redhat-developer/rh-che/
+export BAYESIAN_LOCAL_GIT_REPO=$(pwd)/rh-che/bayesian/
+cd $BAYESIAN_LOCAL_GIT_REPO
+./patch_che.sh
+
+cd $CHE_LOCAL_GIT_REPO
 mkdir $NPM_CONFIG_PREFIX
 #scl enable rh-nodejs4 'npm install -g bower gulp typings'
 scl enable rh-maven33 rh-nodejs4 'mvn clean install -Pfast'


### PR DESCRIPTION
@kbsingh @shaded-enmity I'm adding component analysis lsp plugin to Che build with this PR

The tricky part is that we need  to clone https://github.com/redhat-developer/rh-che/ that is private repository. @kbsingh can we use a secret to store a github token to clone redhat-developer/rh-che?

Or should we move the component analysis stuff to a public repository? 