### PR TITLE
Build che-dependencies too

### DIFF
--- a/build_che.sh
+++ b/build_che.sh
@@ -5,6 +5,15 @@
 
 . config 
 
+# First build maven parent project that holds
+# versions of all Che dependencies
+# This is needed when we need to upgrate a
+# dependency and we can't wait until the CQ is
+# approved and PR is merged in upstream master branch 
+git clone -b ${GIT_BRANCH_DEP} ${GIT_REPO_DEP}
+cd che-dependencies
+scl enable rh-maven33 'mvn -B clean install'
+
 git clone -b ${GIT_BRANCH} ${GIT_REPO}
 cd che 
 mkdir $NPM_CONFIG_PREFIX

--- a/config
+++ b/config
@@ -6,5 +6,8 @@ BuildUser=chebuilder
 export GIT_REPO=https://github.com/eclipse/che
 export GIT_BRANCH=openshift-connector
 
+export GIT_REPO_DEP=https://github.com/eclipse/che-dependencies
+export GIT_BRANCH_DEP=openshift-connector
+
 export NPM_CONFIG_PREFIX=~/.che_node_modules
 export PATH=$NPM_CONFIG_PREFIX/bin:$PATH


### PR DESCRIPTION
This is needed to build Che openshift-connector branch without waiting that all CQ for every direct and transitive dependency are approved and the relative PR get approved and merge into upstream master branch.